### PR TITLE
Accommodate the "embed" parameter in filterApps()

### DIFF
--- a/src/main/java/mesosphere/marathon/client/Marathon.java
+++ b/src/main/java/mesosphere/marathon/client/Marathon.java
@@ -1,7 +1,7 @@
 package mesosphere.marathon.client;
 
-import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import feign.Param;
 import feign.RequestLine;
@@ -34,7 +34,7 @@ public interface Marathon {
 	GetAppsResponse filterApps(@Param("cmd") String commandSubstring,
 			@Param(value = "id", expander = AppIdNormalizer.class) String idSubstring,
 			@Param("labelSelector") String labelSelector,
-			@Param("embed") EnumSet<EmbeddedAppResource> embeddedResources);
+			@Param("embed") Set<EmbeddedAppResource> embeddedResources);
 
 	@RequestLine("GET /v2/apps/{id}")
 	GetAppResponse getApp(@Param(value = "id", expander = AppIdNormalizer.class) String id) throws MarathonException;

--- a/src/main/java/mesosphere/marathon/client/Marathon.java
+++ b/src/main/java/mesosphere/marathon/client/Marathon.java
@@ -1,12 +1,15 @@
 package mesosphere.marathon.client;
 
+import java.util.EnumSet;
 import java.util.List;
 
 import feign.Param;
+import feign.RequestLine;
 import mesosphere.marathon.client.model.v2.App;
 import mesosphere.marathon.client.model.v2.DeleteAppTaskResponse;
 import mesosphere.marathon.client.model.v2.DeleteAppTasksResponse;
 import mesosphere.marathon.client.model.v2.Deployment;
+import mesosphere.marathon.client.model.v2.EmbeddedAppResource;
 import mesosphere.marathon.client.model.v2.GetAppResponse;
 import mesosphere.marathon.client.model.v2.GetAppTasksResponse;
 import mesosphere.marathon.client.model.v2.GetAppsResponse;
@@ -16,7 +19,6 @@ import mesosphere.marathon.client.model.v2.Group;
 import mesosphere.marathon.client.model.v2.Result;
 import mesosphere.marathon.client.utils.AppIdNormalizer;
 import mesosphere.marathon.client.utils.MarathonException;
-import feign.RequestLine;
 
 public interface Marathon {
     // Apps
@@ -24,9 +26,15 @@ public interface Marathon {
 	GetAppsResponse getApps();
 
 	@RequestLine("GET /v2/apps?cmd={cmd}&id={id}&label={labelSelector}")
-	GetAppsResponse filterApps(@Param("cmd") String command,
-			@Param(value = "id", expander = AppIdNormalizer.class) String id,
+	GetAppsResponse filterApps(@Param("cmd") String commandSubstring,
+			@Param(value = "id", expander = AppIdNormalizer.class) String idSubstring,
 			@Param("labelSelector") String labelSelector);
+
+	@RequestLine("GET /v2/apps?cmd={cmd}&id={id}&label={labelSelector}&embed={embed}")
+	GetAppsResponse filterApps(@Param("cmd") String commandSubstring,
+			@Param(value = "id", expander = AppIdNormalizer.class) String idSubstring,
+			@Param("labelSelector") String labelSelector,
+			@Param("embed") EnumSet<EmbeddedAppResource> embeddedResources);
 
 	@RequestLine("GET /v2/apps/{id}")
 	GetAppResponse getApp(@Param(value = "id", expander = AppIdNormalizer.class) String id) throws MarathonException;

--- a/src/main/java/mesosphere/marathon/client/model/v2/EmbeddedAppResource.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/EmbeddedAppResource.java
@@ -1,0 +1,25 @@
+package mesosphere.marathon.client.model.v2;
+
+/**
+ * Enumerates the additional resources that clients may request Marathon to include in response pertaining to
+ * applications.
+ */
+public enum EmbeddedAppResource {
+	APP_TASKS("apps.tasks"),
+	APP_COUNTS("apps.counts"),
+	APP_DEPLOYMENTS("apps.deployments"),
+	APP_LAST_TASK_FAILURES("apps.lastTaskFailures"),
+	APP_FAILURES("apps.failures"),
+	APP_TASK_STATS("apps.taskStats");
+
+	private final String parameterValue;
+
+	EmbeddedAppResource(String parameterValue) {
+		this.parameterValue = parameterValue;
+	}
+
+	@Override
+	public String toString() {
+		return parameterValue;
+	}
+}


### PR DESCRIPTION
Marathon allows clients to [request various application-related details be embedded](https://mesosphere.github.io/marathon/docs/generated/api.html#v2_apps_get) in responses that describe applications. Expose the "embed" query parameter on an overload of the `Marathon#filterApps()` method.
