### PR TITLE
Declare media type headers in Marathon interface

### DIFF
--- a/src/main/java/mesosphere/marathon/client/Marathon.java
+++ b/src/main/java/mesosphere/marathon/client/Marathon.java
@@ -2,7 +2,9 @@ package mesosphere.marathon.client;
 
 import java.util.List;
 
+import feign.Headers;
 import feign.Param;
+import feign.RequestLine;
 import mesosphere.marathon.client.model.v2.App;
 import mesosphere.marathon.client.model.v2.DeleteAppTaskResponse;
 import mesosphere.marathon.client.model.v2.DeleteAppTasksResponse;
@@ -16,8 +18,8 @@ import mesosphere.marathon.client.model.v2.Group;
 import mesosphere.marathon.client.model.v2.Result;
 import mesosphere.marathon.client.utils.AppIdNormalizer;
 import mesosphere.marathon.client.utils.MarathonException;
-import feign.RequestLine;
 
+@Headers("Accept: application/json")
 public interface Marathon {
     // Apps
 	@RequestLine("GET /v2/apps")
@@ -37,9 +39,11 @@ public interface Marathon {
 	@RequestLine("GET /v2/tasks")
 	GetTasksResponse getTasks();
 
+	@Headers("Content-Type: application/json")
 	@RequestLine("POST /v2/apps")
 	App createApp(App app) throws MarathonException;
 
+	@Headers("Content-Type: application/json")
 	@RequestLine("PUT /v2/apps/{app_id}?force={force}")
 	void updateApp(@Param(value = "app_id", expander = AppIdNormalizer.class) String appId, App app,
                    @Param("force") boolean force) throws MarathonException;
@@ -60,9 +64,11 @@ public interface Marathon {
 			@Param("task_id") String taskId, @Param("scale") String scale);
 
     // Groups
+	@Headers("Content-Type: application/json")
 	@RequestLine("POST /v2/groups")
 	Result createGroup(Group group) throws MarathonException;
 
+	@Headers("Content-Type: application/json")
 	@RequestLine("PUT /v2/groups/{id}")
 	Result updateGroup(@Param("id") String id, Group group, @Param("force") boolean force,
 			@Param("dryRun") boolean dryRun) throws MarathonException;
@@ -78,10 +84,10 @@ public interface Marathon {
     // Deployments
 	@RequestLine("GET /v2/deployments")
 	List<Deployment> getDeployments();
-	
+
 	@RequestLine("DELETE /v2/deployments/{deploymentId}")
 	void cancelDeploymentAndRollback(@Param("deploymentId") String id);
-	
+
 	@RequestLine("DELETE /v2/deployments/{deploymentId}?force=true")
 	void cancelDeployment(@Param("deploymentId") String id);
 

--- a/src/main/java/mesosphere/marathon/client/MarathonClient.java
+++ b/src/main/java/mesosphere/marathon/client/MarathonClient.java
@@ -1,45 +1,20 @@
 package mesosphere.marathon.client;
 
-import mesosphere.marathon.client.utils.MarathonException;
-import mesosphere.marathon.client.utils.ModelUtils;
 import feign.Feign;
-import feign.RequestInterceptor;
-import feign.RequestTemplate;
 import feign.Response;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
 import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
+import mesosphere.marathon.client.utils.MarathonException;
+import mesosphere.marathon.client.utils.ModelUtils;
 
 public final class MarathonClient {
 	private MarathonClient() {
 	}
 
-	static final class MarathonHeadersInterceptor implements RequestInterceptor {
-		@Override
-		public void apply(RequestTemplate template) {
-			template.header("Accept", "application/json");
-			if (requestSendsBody(template)) {
-				template.header("Content-Type", "application/json");
-			}
-		}
-
-		private static boolean requestSendsBody(RequestTemplate template) {
-			return requestMethodSendsBody(template.method());
-		}
-
-		private static boolean requestMethodSendsBody(String method) {
-			// RFC 2616 §5.1.1: Method tokens are case-sensitive.
-			switch (method) {
-			case "POST":
-			case "PUT":
-				return true;
-			default:
-				return false;
-			}
-		}
-	}
-
-	static final class MarathonErrorDecoder implements ErrorDecoder {
+	private static final class MarathonErrorDecoder implements ErrorDecoder {
 		@Override
 		public Exception decode(String methodKey, Response response) {
 			return new MarathonException(response.status(), response.reason());
@@ -51,12 +26,11 @@ public final class MarathonClient {
 	}
 
 	public static Marathon getInstance(Feign.Builder builder, String endpoint) {
-		final GsonDecoder decoder = new GsonDecoder(ModelUtils.GSON);
-		final GsonEncoder encoder = new GsonEncoder(ModelUtils.GSON);
+		final Decoder decoder = new GsonDecoder(ModelUtils.GSON);
+		final Encoder encoder = new GsonEncoder(ModelUtils.GSON);
 		return builder
 				.encoder(encoder).decoder(decoder)
 				.errorDecoder(new MarathonErrorDecoder())
-				.requestInterceptor(new MarathonHeadersInterceptor())
 				.target(Marathon.class, endpoint);
 	}
 }


### PR DESCRIPTION
Rather than using a `RequestInterceptor` to determine which media type headers to include in the HTTP requests, use annotations to declare the desired headers on the specific methods in the `Marathon` interface.
